### PR TITLE
replaced np.arange with np.linspace

### DIFF
--- a/Python_tool/MuscleParOptTool/Private_functions.py
+++ b/Python_tool/MuscleParOptTool/Private_functions.py
@@ -316,11 +316,6 @@ def sampleMuscleQuantities(osimModel,OSMuscle,muscleQuant, N_EvalPoints):
         
     # assigns an interval of variation following the initial and final value
     # for each dof X
-    CoordinateRanges = {}
-    for pos, dof in enumerate(DOF_Index):
-        CoordinateRanges[str(dof)] = np.arange(CoordinateBoundaries[pos][0] , CoordinateBoundaries[pos][1] + degIncrem[pos], degIncrem[pos])
-    
-    CoordinateCombinations = [dict(zip(CoordinateRanges.keys(), element)) for element in product(*CoordinateRanges.values())]        
         
     # setting up for loops in order to explore all the possible combination of
     # joint angles (looping on all the dofs of each joint for all the joint
@@ -332,7 +327,7 @@ def sampleMuscleQuantities(osimModel,OSMuscle,muscleQuant, N_EvalPoints):
     # The dictionary keys are the DOF_Index in the model
     CoordinateRange = {}
     for pos, dof in enumerate(DOF_Index):
-        CoordinateRange[str(dof)] = np.arange(CoordinateBoundaries[pos][0] , CoordinateBoundaries[pos][1] + degIncrem[pos], degIncrem[pos])
+        CoordinateRange[str(dof)] = np.linspace(CoordinateBoundaries[pos][0] , CoordinateBoundaries[pos][1], N_EvalPoints)
     
     # generate a list of dictionaries to explore all the possible combination of
     # joit angle


### PR DESCRIPTION
Hi,

I removed unused and repeated lines and replaced np.arange with np.linspace, because I got more than N_EvalPoints elements. To reproduce, run sampleMuscleQuantities function only for 'addbrev_r' muscle with 10 N_EvalPoints. Model: https://simtk.org/projects/fbmodpassivecal

The output of CoordinateRange variable would be as follows. Please note that the 7th coordinate has 11 elements and the output of the function will have 1100 rows. In the MATLAB version, however, it has 1000 rows, which makes sense (10^3). Also, the last range of coordinate is out of definition (hip_adduction_r RoM: -0.87266463 to 0.52359878)

{'6': array([-0.52359878, -0.23271057,  0.05817764,  0.34906585,  0.63995406,  0.93084226,  1.22173047,  1.51261868,  1.80350689,  2.0943951 ]), 
'7': array([-0.87266463, -0.71752425, -0.56238387, -0.40724349, -0.25210311,  -0.09696274,  0.05817764,  0.21331802,  0.3684584 ,  0.52359878, 0.67873916]), 
 '8': array([-0.6981317 , -0.54299132, -0.38785094, -0.23271057, -0.07757019, 0.07757019,  0.23271057,  0.38785094,  0.54299132,  0.6981317 ])}

Some notes from [numpy arange](https://numpy.org/doc/stable/reference/generated/numpy.arange.html) documentation to support:

> When using a non-integer step, such as 0.1, it is often better to use [numpy.linspace](https://numpy.org/doc/stable/reference/generated/numpy.linspace.html#numpy.linspace). ... The length of the output might not be numerically stable.

Now the output is identical to the MATLAB version.